### PR TITLE
Update normalize function to put in state file full certificate data instead of hash

### DIFF
--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -1,6 +1,6 @@
 package aws
 
-import (	
+import (
 	"fmt"
 	"log"
 	"regexp"
@@ -227,7 +227,7 @@ func normalizeCert(cert interface{}) string {
 	default:
 		return ""
 	}
-	
+
 	cleanVal := strings.TrimSpace(rawCert)
 	return cleanVal
 }

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -231,17 +231,3 @@ func normalizeCert(cert interface{}) string {
 	cleanVal := strings.TrimSpace(rawCert)
 	return cleanVal
 }
-
-// strip CRs from raw literals. Lifted from go/scanner/scanner.go
-// See https://github.com/golang/go/blob/release-branch.go1.6/src/go/scanner/scanner.go#L479
-func stripCR(b []byte) []byte {
-	c := make([]byte, len(b))
-	i := 0
-	for _, ch := range b {
-		if ch != '\r' {
-			c[i] = ch
-			i++
-		}
-	}
-	return c[:i]
-}

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -228,8 +228,7 @@ func normalizeCert(cert interface{}) string {
 		rawCert = *cert
 	default:
 		return ""
-	}
-	
+	}	
 	return strings.TrimSpace(rawCert)
 }
 

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -1,8 +1,6 @@
 package aws
 
-import (
-	"crypto/sha1"
-	"encoding/hex"
+import (	
 	"fmt"
 	"log"
 	"regexp"
@@ -228,8 +226,10 @@ func normalizeCert(cert interface{}) string {
 		rawCert = *cert
 	default:
 		return ""
-	}	
-	return strings.TrimSpace(rawCert)
+	}
+	
+	cleanVal := strings.TrimSpace(rawCert)
+	return cleanVal
 }
 
 // strip CRs from raw literals. Lifted from go/scanner/scanner.go

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -229,9 +229,8 @@ func normalizeCert(cert interface{}) string {
 	default:
 		return ""
 	}
-
-	cleanVal := sha1.Sum(stripCR([]byte(strings.TrimSpace(rawCert))))
-	return hex.EncodeToString(cleanVal[:])
+	
+	return strings.TrimSpace(rawCert)
 }
 
 // strip CRs from raw literals. Lifted from go/scanner/scanner.go


### PR DESCRIPTION
The current behaviour of the resource is to put a hash of certificate data (private key, certificate body, chain code) in the state file.
It causes an error because the provider sends these hashes of unmodified fields instead of source data on resource update.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10847.
Also, _may_ fix #9809.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
go test ./... -timeout=30s -parallel=4
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
ok      github.com/terraform-providers/terraform-provider-aws/aws       18.835s
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      (cached)
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags (cached)
...
```
### Test cases:
#### Update imported certificate
1. import new certificate by using acm_certificate resource
2. update certificate_body field
3. update imported certificate

#### current version
`Error: Error updating certificate: ValidationException: com.amazonaws.pki.acm.exceptions.external.ValidationException: Could not validate the certificate with the certificate chain.`

result: imported certificate was not updated.

#### fixed version (pr)
`Apply complete`
result: imported certificate was updated successfully.